### PR TITLE
Fix build process on case-sensitive file systems

### DIFF
--- a/src/Base64.cpp
+++ b/src/Base64.cpp
@@ -16,7 +16,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include "base64.h"
+#include "Base64.h"
 
 #if defined(ESP32)
 #include <pgmspace.h>


### PR DESCRIPTION
The initial version uses `base64.h` as the file in `src/Base64.cpp`, this will break the build process on case-sensitive filesystem, as the compiler will look for `base64.h` in every include directories which leads to the following error:

```sh
Compiling .pio/build/esp-wrover-kit/lib66c/AzureIoTLiteClient/Base64.cpp.o
Compiling .pio/build/esp-wrover-kit/lib66c/AzureIoTLiteClient/IotcUtils.cpp.o
In file included from lib/AzureIoTLiteClient/src/Base64.cpp:19:0:
/home/winter/.platformio/packages/framework-arduinoespressif32/cores/esp32/base64.h:7:12: error: 'String' does not name a type
     static String encode(const uint8_t * data, size_t length);
            ^
/home/winter/.platformio/packages/framework-arduinoespressif32/cores/esp32/base64.h:8:12: error: 'String' does not name a type
     static String encode(const String& text);
```

This pull request is aimed to fix this issue on case-sensitive filesystem such as ext4 which is widely used by Linux.